### PR TITLE
v0.7.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sfe1ed40
-
-channels:
-  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+    build: or-tools

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
+upload_channels:
+  - sfe1ed40
+
 channels:
-    build: or-tools
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,14 +19,14 @@ requirements:
     - {{ compiler('c') }}
   host:
     - python
-    - setuptools >=30
+    - setuptools
     - wheel
-    - cython >=0.29
-    - numpy >=1.23.0
+    - cython 0.29.33
+    - numpy 1.23.5
     - pip
   run:
     - python
-    - ortools-python >=9.4.1874
+    - ortools-python >=9.4
     - scipy >=1.6.3
     - six
     - joblib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,8 @@ source:
   sha256: e3cf1601ebe91c2317fd595399153e81c450085b15a072ea67f9850175a12102
 
 build:
-  skip: true  # [py<38]
+  # or-tools is missing on Windows due to OpenBLAS requirement 
+  skip: true  # [py<38 or win]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,6 +55,7 @@ about:
     a fast C++ implementation.
   license: BSD-3-Clause
   license_file: LICENSE
+  license_family: BSD
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,61 @@
+{% set name = "k-means-constrained" %}
+{% set version = "0.7.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: e3cf1601ebe91c2317fd595399153e81c450085b15a072ea67f9850175a12102
+
+build:
+  skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - python
+    - setuptools >=30
+    - wheel
+    - cython >=0.29
+    - numpy >=1.23.0
+    - pip
+  run:
+    - python
+    - ortools-python >=9.4.1874
+    - scipy >=1.6.3
+    - six
+    - joblib
+    - {{ pin_compatible('numpy') }}
+
+test:
+  imports:
+    - k_means_constrained
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/joshlk/k-means-constrained
+  dev_url: https://github.com/joshlk/k-means-constrained
+  doc_url: https://joshlk.github.io/k-means-constrained/
+  summary: K-Means clustering constrained with minimum and maximum cluster size
+  description: |
+    K-means clustering implementation whereby a minimum and/or maximum size for 
+    each cluster can be specified.
+    This K-means implementation modifies the cluster assignment step (E in EM) 
+    by formulating it as a Minimum Cost Flow (MCF) linear network optimisation 
+    problem. This is then solved using a cost-scaling push-relabel algorithm 
+    and uses Google's Operations Research tools's SimpleMinCostFlow which is 
+    a fast C++ implementation.
+  license: BSD-3-Clause
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - ELundby45


### PR DESCRIPTION
# k-means-constrained v0.7.2❄️ 

upstream: https://github.com/joshlk/k-means-constrained

## Notes
- This is a ❄️ package and will be uploaded to the ❄️ channel. The abs.yaml file will be updated upon approval
- Windows is skipped due to `or-tools` being reliant on OpenBLAS
- This is a new feedstock